### PR TITLE
Use operationName directly

### DIFF
--- a/packages/services/service-common/package.json
+++ b/packages/services/service-common/package.json
@@ -9,7 +9,6 @@
     "fastify": "3.29.3",
     "fastify-cors": "6.0.2",
     "fastify-plugin": "3.0.1",
-    "graphql": "16.5.0",
     "prom-client": "14.0.1",
     "zod": "3.15.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -659,7 +659,6 @@ importers:
       fastify: 3.29.3
       fastify-cors: 6.0.2
       fastify-plugin: 3.0.1
-      graphql: 16.5.0
       prom-client: 14.0.1
       zod: 3.15.1
     dependencies:
@@ -667,7 +666,6 @@ importers:
       fastify: 3.29.3
       fastify-cors: 6.0.2
       fastify-plugin: 3.0.1
-      graphql: 16.5.0
       prom-client: 14.0.1
       zod: 3.15.1
     devDependencies:


### PR DESCRIPTION
Parsing is super expensive
It could reuse the cache of `@envelop/parser-cache` but it adds a bit of complexity...